### PR TITLE
Export native cardinality constraints as faithful DIMACS CNF

### DIFF
--- a/minicard/Solver.cc
+++ b/minicard/Solver.cc
@@ -1210,7 +1210,12 @@ void Solver::toDimacs(const char *file, const vec<Lit>& assumps)
     FILE* f = fopen(file, "w");
     if (f == NULL)
         fprintf(stderr, "could not open file %s\n", file), exit(1);
-    toDimacs(f, assumps);
+    try {
+        toDimacs(f, assumps);
+    } catch (...) {
+        fclose(f);
+        throw;
+    }
     fclose(f);
 }
 

--- a/minicard/Solver.cc
+++ b/minicard/Solver.cc
@@ -26,6 +26,8 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 **************************************************************************************************/
 
 #include <math.h>
+#include <limits.h>
+#include <stdexcept>
 
 #include "mtl/Sort.h"
 #include "minicard/Solver.h"
@@ -1124,7 +1126,7 @@ bool Solver::implies(const vec<Lit>& assumps, vec<Lit>& out, bool all=false)
 //=================================================================================================
 // Writing CNF to DIMACS:
 // 
-// FIXME: this needs to be rewritten completely.
+// Native cardinality constraints are encoded only for export, not for solving.
 
 static Var mapVar(Var x, vec<Var>& map, Var& max)
 {
@@ -1136,20 +1138,76 @@ static Var mapVar(Var x, vec<Var>& map, Var& max)
 }
 
 
+static uint64_t writeDimacsClause(FILE* f, int a, int b = 0, int c = 0)
+{
+    if (f != NULL){
+        fprintf(f, "%d ", a);
+        if (b != 0) fprintf(f, "%d ", b);
+        if (c != 0) fprintf(f, "%d ", c);
+        fprintf(f, "0\n");
+    }
+    return 1;
+}
+
+
+static uint64_t writeDimacsConstraint(FILE* f, const Clause& c, vec<Var>& map, Var& max)
+{
+    if (!c.is_atmost()){
+        for (int i = 0; i < c.size(); i++){
+            int v = mapVar(var(c[i]), map, max) + 1;
+            if (f != NULL) fprintf(f, "%d ", sign(c[i]) ? -v : v);
+        }
+        if (f != NULL) fprintf(f, "0\n");
+        return 1;
+    }
+
+    int bound = c.size() - c.atmost_watches() + 1;
+    if (bound >= c.size()) return 0;
+    if (bound < 0){
+        if (f != NULL) fprintf(f, "0\n");
+        return 1;
+    }
+
+    // A sequential counter: previous[j] records at least j+1 true occurrences
+    // in the processed prefix. Occurrences, including duplicates, count separately.
+    // A NULL stream performs the identical allocation/counting pass for the header.
+    vec<int> previous, current;
+    uint64_t clauses = 0;
+    for (int i = 0; i < c.size(); i++){
+        int v = mapVar(var(c[i]), map, max) + 1;
+        int p = sign(c[i]) ? -v : v;
+        if (bound == 0){
+            clauses += writeDimacsClause(f, -p);
+            continue;
+        }
+        current.clear();
+        for (int j = 0; j < bound && j <= i; j++){
+            if (max == INT_MAX) throw std::overflow_error("DIMACS auxiliary variable limit exceeded");
+            current.push(++max);
+        }
+        clauses += writeDimacsClause(f, -p, current[0]);
+        for (int j = 0; j < previous.size(); j++){
+            clauses += writeDimacsClause(f, -previous[j], current[j]);
+            if (j + 1 < bound)
+                clauses += writeDimacsClause(f, -p, -previous[j], current[j + 1]);
+            else
+                clauses += writeDimacsClause(f, -p, -previous[j]);
+        }
+        current.moveTo(previous);
+    }
+    return clauses;
+}
+
+
 void Solver::toDimacs(FILE* f, Clause& c, vec<Var>& map, Var& max)
 {
-    if (satisfied(c)) return;
-
-    for (int i = 0; i < c.size(); i++)
-        if (value(c[i]) != l_False)
-            fprintf(f, "%s%d ", sign(c[i]) ? "-" : "", mapVar(var(c[i]), map, max)+1);
-    fprintf(f, "0\n");
+    writeDimacsConstraint(f, c, map, max);
 }
 
 
 void Solver::toDimacs(const char *file, const vec<Lit>& assumps)
 {
-    FILE* f = fopen(file, "wr");
+    FILE* f = fopen(file, "w");
     if (f == NULL)
         fprintf(stderr, "could not open file %s\n", file), exit(1);
     toDimacs(f, assumps);
@@ -1164,38 +1222,33 @@ void Solver::toDimacs(FILE* f, const vec<Lit>& assumps)
         fprintf(f, "p cnf 1 2\n1 0\n-1 0\n");
         return; }
 
-    vec<Var> map; Var max = 0;
-
-    // Cannot use removeClauses here because it is not safe
-    // to deallocate them at this point. Could be improved.
-    int cnt = 0;
+    // Preserve original variable numbers. Root assignments must be exported too:
+    // insertion and simplification may have removed the clauses that implied them.
+    vec<Var> map;
+    for (Var v = 0; v < nVars(); v++) map.push(v);
+    uint64_t cnt = assumps.size();
+    for (int i = 0; i < assumps.size(); i++)
+        if (var(assumps[i]) < 0 || var(assumps[i]) >= nVars())
+            throw std::out_of_range("DIMACS assumption refers to an unknown variable");
+    for (Var v = 0; v < nVars(); v++)
+        if (value(v) != l_Undef && level(v) == 0) cnt++;
+    Var max = nVars();
     for (int i = 0; i < clauses.size(); i++)
-        if (!satisfied(ca[clauses[i]]))
-            cnt++;
-        
+        cnt += writeDimacsConstraint(NULL, ca[clauses[i]], map, max);
+
+    fprintf(f, "p cnf %d %llu\n", max, (unsigned long long)cnt);
+    for (Var v = 0; v < nVars(); v++)
+        if (value(v) != l_Undef && level(v) == 0)
+            writeDimacsClause(f, value(v) == l_True ? v + 1 : -(v + 1));
+    for (int i = 0; i < assumps.size(); i++)
+        writeDimacsClause(f, sign(assumps[i]) ? -(var(assumps[i]) + 1) : var(assumps[i]) + 1);
+    Var next = nVars();
     for (int i = 0; i < clauses.size(); i++)
-        if (!satisfied(ca[clauses[i]])){
-            Clause& c = ca[clauses[i]];
-            for (int j = 0; j < c.size(); j++)
-                if (value(c[j]) != l_False)
-                    mapVar(var(c[j]), map, max);
-        }
-
-    // Assumptions are added as unit clauses:
-    cnt += assumptions.size();
-
-    fprintf(f, "p cnf %d %d\n", max, cnt);
-
-    for (int i = 0; i < assumptions.size(); i++){
-        assert(value(assumptions[i]) != l_False);
-        fprintf(f, "%s%d 0\n", sign(assumptions[i]) ? "-" : "", mapVar(var(assumptions[i]), map, max)+1);
-    }
-
-    for (int i = 0; i < clauses.size(); i++)
-        toDimacs(f, ca[clauses[i]], map, max);
+        writeDimacsConstraint(f, ca[clauses[i]], map, next);
+    assert(next == max);
 
     if (verbosity > 0)
-        printf("c Wrote %d clauses with %d variables.\n", cnt, max);
+        printf("c Wrote %llu clauses with %d variables.\n", (unsigned long long)cnt, max);
 }
 
 

--- a/minicard/Solver.h
+++ b/minicard/Solver.h
@@ -79,7 +79,9 @@ public:
     // Adopted from newer version of Minisat
     bool    implies      (const vec<Lit>& assumps, vec<Lit>& out, bool all);
 
-    void    toDimacs     (FILE* f, const vec<Lit>& assumps);            // Write CNF to file in DIMACS-format.
+    // Write CNF with original variable numbers, root assignments and supplied assumptions.
+    // Native AtMost constraints use an export-only sequential counter with auxiliary variables.
+    void    toDimacs     (FILE* f, const vec<Lit>& assumps);
     void    toDimacs     (const char *file, const vec<Lit>& assumps);
     void    toDimacs     (FILE* f, Clause& c, vec<Var>& map, Var& max);
 

--- a/tests/dimacs_export.cpp
+++ b/tests/dimacs_export.cpp
@@ -1,25 +1,34 @@
 // Compile with minicard/Solver.cc, utils/Options.cc and utils/System.cc.
 // Compare every original-variable assignment with its exported CNF extension.
 #include "minicard/Solver.h"
+#include <algorithm>
 #include <cstdlib>
 #include <iostream>
 #include <random>
 #include <sstream>
 #include <string>
+#include <stdexcept>
 #include <vector>
+#include <unistd.h>
+#ifdef __linux__
+#include <dirent.h>
+#endif
 using namespace Minisat;
 struct Constraint { std::vector<int> literals; int bound; bool clause; };
 static Lit lit(int x) { return mkLit(std::abs(x)-1, x<0); }
 static bool value(int x, unsigned mask) { return bool(mask & (1u<<(std::abs(x)-1))) != (x<0); }
 static unsigned checks = 0;
+static unsigned exhaustive_tables = 0;
 static void require(bool condition) { if (!condition) { std::cerr << "FAIL at check " << checks << '\n'; std::exit(1); } }
 
-static void check(Solver& source, int n, const std::vector<Constraint>& constraints, const std::vector<int>& assumptions) {
+static void check(Solver& source, int n, const std::vector<Constraint>& constraints,
+                  const std::vector<int>& assumptions, const char* path = NULL) {
     vec<Lit> as;
     for (int x : assumptions) as.push(lit(x));
-    FILE* file = tmpfile();
+    if(path!=NULL)source.toDimacs(path,as);
+    FILE* file = path==NULL ? tmpfile() : fopen(path,"r");
     require(file != NULL);
-    source.toDimacs(file, as);
+    if(path==NULL)source.toDimacs(file, as);
     rewind(file);
     std::string text;
     for (int c; (c = fgetc(file)) != EOF;) text += char(c);
@@ -30,18 +39,35 @@ static void check(Solver& source, int n, const std::vector<Constraint>& constrai
     unsigned long long count;
     require(bool(input >> p >> kind >> variables >> count) && p == "p" && kind == "cnf" && variables >= 0);
     Solver decoded;
+    std::vector<std::vector<int>> cnf;
     for (int i = 0; i < std::max(variables,n); ++i) decoded.newVar();
     for (unsigned long long i = 0; i < count; ++i) {
         vec<Lit> clause;
+        cnf.push_back({});
         int x;
         do {
             require(bool(input >> x) && x >= -variables && x <= variables);
-            if (x) clause.push(lit(x));
+            if (x) {clause.push(lit(x));cnf.back().push_back(x);}
         } while (x);
         decoded.addClause(clause);
     }
     std::string extra;
     require(!(input >> extra));
+    // For small exports, eliminate dependence on *any* SAT engine: enumerate
+    // all assignments, including the auxiliary counter variables.
+    std::vector<bool> attainable(1u<<n,false);
+    if (variables <= 12) {
+        ++exhaustive_tables;
+        for (unsigned mask=0;mask<(1u<<std::max(variables,n));++mask) {
+            bool valid=true;
+            for (const auto& clause:cnf) {
+                bool satisfied=false;
+                for(int x:clause)satisfied|=value(x,mask);
+                if(!satisfied){valid=false;break;}
+            }
+            if(valid)attainable[mask&((1u<<n)-1)]=true;
+        }
+    }
     for (unsigned mask = 0; mask < (1u << n); ++mask) {
         bool expected = true;
         for (int x : assumptions) expected &= value(x,mask);
@@ -54,6 +80,7 @@ static void check(Solver& source, int n, const std::vector<Constraint>& constrai
         for (int j = 0; j < n; ++j) fixed.push(mkLit(j, !(mask & (1u << j))));
         ++checks;
         require(decoded.solveLimited(fixed) == (expected ? l_True : l_False));
+        if(variables<=12)require(attainable[mask]==expected);
     }
 }
 
@@ -63,7 +90,47 @@ static void add(Solver& s, const Constraint& c) {
     if (c.clause) s.addClause(literals); else s.addAtMost(literals,c.bound);
 }
 
+#ifdef __linux__
+static unsigned descriptor_count() {
+    DIR* dir=opendir("/proc/self/fd");require(dir!=NULL);
+    unsigned count=0;while(readdir(dir)!=NULL)++count;
+    closedir(dir);return count;
+}
+#endif
+
+static void filename_api() {
+    char path[]="minicard-export-test-XXXXXX";
+    int fd=mkstemp(path);require(fd>=0);close(fd);
+    Solver s;for(int i=0;i<3;++i)s.newVar();
+    std::vector<Constraint> constraints{{{1,2,3},1,false}};add(s,constraints[0]);
+    check(s,3,constraints,{},path);check(s,3,constraints,{3},path);
+#ifdef __linux__
+    unsigned before=descriptor_count();
+#endif
+    vec<Lit> invalid;invalid.push(mkLit(3));
+    for(int i=0;i<64;++i) {
+        bool rejected=false;
+        try{s.toDimacs(path,invalid);}catch(const std::out_of_range&){rejected=true;}
+        require(rejected);
+    }
+#ifdef __linux__
+    bool closed=descriptor_count()==before;
+#endif
+    require(unlink(path)==0);
+#ifdef __linux__
+    require(closed);
+#endif
+}
+
 int main() {
+    filename_api();
+    {
+        Solver empty;check(empty,0,{},{});
+        Solver root;for(int i=0;i<3;++i)root.newVar();
+        std::vector<Constraint> constraints{{{3},0,true}};
+        add(root,constraints[0]);root.simplify();
+        check(root,3,constraints,{});check(root,3,constraints,{-3});
+    }
     for (int bound = -1; bound <= 5; ++bound) {
         Solver s;
         s.detect_clause = false;
@@ -98,5 +165,5 @@ int main() {
             check(s,n,constraints,{stage%2 ? 1 : -1});
         }
     }
-    std::cout << "PASS DIMACS assignment checks=" << checks << '\n';
+    std::cout << "PASS DIMACS assignment checks=" << checks << " independent truth tables=" << exhaustive_tables << '\n';
 }

--- a/tests/dimacs_export.cpp
+++ b/tests/dimacs_export.cpp
@@ -1,0 +1,102 @@
+// Compile with minicard/Solver.cc, utils/Options.cc and utils/System.cc.
+// Compare every original-variable assignment with its exported CNF extension.
+#include "minicard/Solver.h"
+#include <cstdlib>
+#include <iostream>
+#include <random>
+#include <sstream>
+#include <string>
+#include <vector>
+using namespace Minisat;
+struct Constraint { std::vector<int> literals; int bound; bool clause; };
+static Lit lit(int x) { return mkLit(std::abs(x)-1, x<0); }
+static bool value(int x, unsigned mask) { return bool(mask & (1u<<(std::abs(x)-1))) != (x<0); }
+static unsigned checks = 0;
+static void require(bool condition) { if (!condition) { std::cerr << "FAIL at check " << checks << '\n'; std::exit(1); } }
+
+static void check(Solver& source, int n, const std::vector<Constraint>& constraints, const std::vector<int>& assumptions) {
+    vec<Lit> as;
+    for (int x : assumptions) as.push(lit(x));
+    FILE* file = tmpfile();
+    require(file != NULL);
+    source.toDimacs(file, as);
+    rewind(file);
+    std::string text;
+    for (int c; (c = fgetc(file)) != EOF;) text += char(c);
+    fclose(file);
+    std::istringstream input(text);
+    std::string p, kind;
+    int variables;
+    unsigned long long count;
+    require(bool(input >> p >> kind >> variables >> count) && p == "p" && kind == "cnf" && variables >= 0);
+    Solver decoded;
+    for (int i = 0; i < std::max(variables,n); ++i) decoded.newVar();
+    for (unsigned long long i = 0; i < count; ++i) {
+        vec<Lit> clause;
+        int x;
+        do {
+            require(bool(input >> x) && x >= -variables && x <= variables);
+            if (x) clause.push(lit(x));
+        } while (x);
+        decoded.addClause(clause);
+    }
+    std::string extra;
+    require(!(input >> extra));
+    for (unsigned mask = 0; mask < (1u << n); ++mask) {
+        bool expected = true;
+        for (int x : assumptions) expected &= value(x,mask);
+        for (const auto& c : constraints) {
+            int sum = 0;
+            for (int x : c.literals) sum += value(x,mask);
+            expected &= c.clause ? sum > 0 : sum <= c.bound;
+        }
+        vec<Lit> fixed;
+        for (int j = 0; j < n; ++j) fixed.push(mkLit(j, !(mask & (1u << j))));
+        ++checks;
+        require(decoded.solveLimited(fixed) == (expected ? l_True : l_False));
+    }
+}
+
+static void add(Solver& s, const Constraint& c) {
+    vec<Lit> literals;
+    for (int x : c.literals) literals.push(lit(x));
+    if (c.clause) s.addClause(literals); else s.addAtMost(literals,c.bound);
+}
+
+int main() {
+    for (int bound = -1; bound <= 5; ++bound) {
+        Solver s;
+        s.detect_clause = false;
+        for (int j = 0; j < 4; ++j) s.newVar();
+        std::vector<Constraint> constraints{{{1,1,-2,3},bound,false}};
+        add(s,constraints[0]);
+        check(s,4,constraints,{});
+        vec<Lit> old; old.push(mkLit(3)); s.solveLimited(old);
+        check(s,4,constraints,{-4}); // export argument must override the last solve's assumptions
+        check(s,4,constraints,{4,-4});
+    }
+    std::mt19937 rng(987612);
+    for (int trial = 0; trial < 1000; ++trial) {
+        int n = 1 + rng()%7;
+        unsigned planted = rng()%(1u<<n);
+        Solver s;
+        s.detect_clause = trial%2;
+        for (int j = 0; j < n; ++j) s.newVar();
+        std::vector<Constraint> constraints;
+        for (int stage = 0; stage < 8; ++stage) {
+            Constraint c{{},0,rng()%3==0};
+            int length = rng()%(2*n+1), sum = 0;
+            for (int j = 0; j < length; ++j) {
+                int x = (1+int(rng()%n))*(rng()%2?1:-1);
+                c.literals.push_back(x); sum += value(x,planted);
+            }
+            c.bound = trial%2 ? sum : int(rng()%(length+3))-1;
+            if (trial%2 && c.clause && sum == 0) c.literals.push_back(planted&1 ? 1 : -1);
+            constraints.push_back(c); add(s,c);
+            vec<Lit> old; old.push(mkLit(0)); s.solveLimited(old);
+            if (s.okay()) s.garbageCollect();
+            check(s,n,constraints,{stage%2 ? 1 : -1});
+        }
+    }
+    std::cout << "PASS DIMACS assignment checks=" << checks << '\n';
+}


### PR DESCRIPTION
## Problem

`toDimacs()` prints native AtMost constraints as disjunctions without their bounds: AtMost(x1,x2,x3)<=1 becomes `1 2 3 0`, a different constraint. It also uses the previous solve's stored assumptions instead of its supplied argument and can omit necessary root assignments.

## Fix and compatibility

- Retain standard DIMACS CNF, not CNF+. Encode native AtMost constraints using an export-only sequential counter; repeated literal occurrences count separately.
- Preserve original variable numbers. Place auxiliary variables above them. Emit root assignments and the explicitly supplied assumptions.
- Count clauses/auxiliary variables before writing the header. Encoding size is O(n*k), with O(k) temporary counter storage per AtMost.
- Export contradictory assumptions as contradictory unit clauses. Reject out-of-range assumption variables explicitly.
- Correct the filename mode to `w` and close the file if export throws.

The exported formula preserves satisfying assignments over the original variables after existentially eliminating auxiliary variables. No CNF encoding is added to native solving. The file may therefore contain more variables/clauses than the incorrect original export.

This PR is independent of #6 and #7.

## Regression test

`tests/dimacs_export.cpp` validates headers/literal ranges and checks CNF extensions against the original constraints for every original-variable assignment in the test cases. Small exports also receive an independent exhaustive check over **all original and auxiliary variables**, without using a SAT solver as the oracle.

Cases include signed/repeated literals, extreme bounds, root propagation, solves and garbage collection, supplied/stale/contradictory assumptions, empty/root-only formulas, and the filename API. A Linux file-descriptor check exercises exception cleanup.

From the repository root:

```sh
g++ -std=c++17 -O1 -g -fsanitize=address,undefined -fno-omit-frame-pointer -I. \
  tests/dimacs_export.cpp minicard/Solver.cc utils/Options.cc utils/System.cc -o dimacs-export-test
./dimacs-export-test
```

For Release, replace the sanitizer/debug flags with `-O3 -DNDEBUG`; test checks remain enabled.

The regression fails on original upstream source; the descriptor test also failed on the first export patch before its cleanup fix. Final results on the combined three-fix tree: 276,433 assignment checks, including 6,901 independent complete truth tables, pass in both C++17 Release and Address/UndefinedBehavior sanitizers. Native upstream fixtures passed 60/60 on the initial combined fixes. Platform: aarch64, GCC 16.2.1.
